### PR TITLE
[OPEN-STACK] Update to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,9 +1559,9 @@
       "dev": true
     },
     "node_modules/@klient/open-stack-cli": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@klient/open-stack-cli/-/open-stack-cli-1.5.2.tgz",
-      "integrity": "sha512-MrPu8A226C4xsFi0c/+De/EP2A3Tn7oxCGJSpryCpihcr0nXHe0CaPsosu8y+c5vTc6CxdkZgLr+oJZM58uqJA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@klient/open-stack-cli/-/open-stack-cli-1.5.3.tgz",
+      "integrity": "sha512-adxPU+OkrOMaSjkVEFSldHhOz0WbG8ydBp9k8J5L4wK19EMYqkCaVR3eEW+Zoc/Kh4aRjZE2jcrKQdbjRnq11A==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -15409,9 +15409,9 @@
       }
     },
     "@klient/open-stack-cli": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@klient/open-stack-cli/-/open-stack-cli-1.5.2.tgz",
-      "integrity": "sha512-MrPu8A226C4xsFi0c/+De/EP2A3Tn7oxCGJSpryCpihcr0nXHe0CaPsosu8y+c5vTc6CxdkZgLr+oJZM58uqJA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@klient/open-stack-cli/-/open-stack-cli-1.5.3.tgz",
+      "integrity": "sha512-adxPU+OkrOMaSjkVEFSldHhOz0WbG8ydBp9k8J5L4wK19EMYqkCaVR3eEW+Zoc/Kh4aRjZE2jcrKQdbjRnq11A==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist"
   ],
   "open-stack": {
-    "version": "1.5.2"
+    "version": "1.6.0"
   },
   "repository": {
     "url": "https://github.com/klientjs/testing.git",
@@ -28,18 +28,22 @@
     "prettier": "prettier src tsconfig.json .release-it.json .prettierrc .eslintrc --check",
     "prettier:fix": "prettier src tsconfig.json .release-it.json .prettierrc .eslintrc -l --write",
     "test": "jest --passWithNoTests",
-    "dist": "rm -rf dist/* && tsc && tsc --module esnext --outDir dist/esm --moduleResolution node",
+    "dist": "npm run dist:cjs && npm run dist:esm",
     "pre-commit": "npm run lint:fix && npm run prettier:fix && npm test",
     "check": "npm run prettier && npm run lint && npm test",
     "update:dependencies": "npm-check-updates --doctorTest \"npm test && npm run dist\"",
     "update:open-stack": "open-stack update",
     "coverage:badge": "open-stack badge --output .github/badges/coverage.svg --verbose",
     "coverage:open": "open coverage/lcov-report/index.html",
-    "prepare": "npm run prepare:husky",
-    "prepare:husky": "rm -rf .husky && mkdir -p .husky && npm run prepare:pre-commit && npm run prepare:commit-msg && husky install",
+    "prepare": "npm run prepare:reset && npm run prepare:husky",
+    "prepare:husky": "npm run prepare:pre-commit && npm run prepare:commit-msg && husky install",
     "prepare:pre-commit": "husky add .husky/pre-commit 'npm run check'",
     "prepare:commit-msg": "husky add .husky/commit-msg 'npx --no -- commitlint --edit ${1}'",
-    "release": "release-it"
+    "release": "release-it",
+    "dist:cjs": "rm -rf dist/cjs && tsc --outDir dist/cjs --module commonjs",
+    "dist:esm": "rm -rf dist/esm && tsc --outDir dist/esm --module esnext --moduleResolution node",
+    "coverage:serve": "npx --yes http-server coverage/lcov-report",
+    "prepare:reset": "rm -rf .husky && mkdir -p .husky"
   },
   "peerDependencies": {
     "axios": "^0.27.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es6",
-    "module": "commonjs",
     "declaration": true,
-    "outDir": "dist/cjs",
     "strict": true,
     "removeComments": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
# OpenStack update report ( [1.5.2](https://github.com/klientjs/open-stack/releases/tag/1.5.2) :arrow_right: [1.6.0](https://github.com/klientjs/open-stack/releases/tag/1.6.0) )

> Please check below the complete report which is a summary of changes made.
> It can help you to know what changes must be made manually.

## scripts

#### ADDED

  - dist:cjs
  - dist:esm
  - coverage:serve
  - prepare:reset

#### UPDATED

  - dist
  - prepare
  - prepare:husky

#### SKIPPED

  - lint
  - lint:fix
  - prettier
  - prettier:fix
  - test
  - pre-commit
  - check
  - update:dependencies
  - update:open-stack
  - coverage:badge
  - coverage:open
  - prepare:pre-commit
  - prepare:commit-msg
  - release
  - configure

## devDependencies

#### SKIPPED

  - [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli)
  - [@commitlint/config-conventional](https://www.npmjs.com/package/@commitlint/config-conventional)
  - [@klient/open-stack-cli](https://www.npmjs.com/package/@klient/open-stack-cli)
  - [@release-it/conventional-changelog](https://www.npmjs.com/package/@release-it/conventional-changelog)
  - [@types/jest](https://www.npmjs.com/package/@types/jest)
  - [@types/node](https://www.npmjs.com/package/@types/node)
  - [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
  - [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
  - [auto-changelog](https://www.npmjs.com/package/auto-changelog)
  - [commitlint](https://www.npmjs.com/package/commitlint)
  - [conventional-changelog-conventionalcommits](https://www.npmjs.com/package/conventional-changelog-conventionalcommits)
  - [eslint](https://www.npmjs.com/package/eslint)
  - [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)
  - [eslint-config-airbnb-typescript](https://www.npmjs.com/package/eslint-config-airbnb-typescript)
  - [eslint-config-prettier](https://www.npmjs.com/package/eslint-config-prettier)
  - [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
  - [eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports)
  - [husky](https://www.npmjs.com/package/husky)
  - [jest](https://www.npmjs.com/package/jest)
  - [npm-check-updates](https://www.npmjs.com/package/npm-check-updates)
  - [prettier](https://www.npmjs.com/package/prettier)
  - [release-it](https://www.npmjs.com/package/release-it)
  - [ts-jest](https://www.npmjs.com/package/ts-jest)
  - [ts-node](https://www.npmjs.com/package/ts-node)
  - [tsutils](https://www.npmjs.com/package/tsutils)
  - [typescript](https://www.npmjs.com/package/typescript)

## Files

#### UPDATED

  - tsconfig.json

#### SKIPPED

  - .release-it.json
  - .eslintrc
  - .prettierrc
  - .editorconfig
  - .gitignore
  - .commitlintrc
  - jest.config.json
  - CODE_OF_CONDUCT.md
  - CONTRIBUTING.md
  - LICENCE
  - .github/PULL_REQUEST_TEMPLATE.md
  - .github/ISSUE_TEMPLATE/config.yml
  - .github/ISSUE_TEMPLATE/4_Help.yaml
  - .github/ISSUE_TEMPLATE/3_Documentation.yaml
  - .github/ISSUE_TEMPLATE/2_Feature_request.yaml
  - .github/ISSUE_TEMPLATE/1_Bug_report.yaml
  - .github/workflows/unpublish.yml
  - .github/workflows/tests.yml
  - .github/workflows/release.yml
  - .github/workflows/publish.yml
  - .github/workflows/open-stack.yml
  - .github/workflows/dependencies.yml
  - .github/workflows/cache.yml

*This message has been auto generated*